### PR TITLE
Fixed permission handing on command error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `event trigger` command in order to manually trigger events outside of their set dispatch time.
 - Console message are now prefixed based on type (LOG, DEBUG, ERROR)
+- Users are alerted if they do not have the correct permission to run the command.
 
 ### Changed
 - `event list` and `event view` now display the paused state.
@@ -19,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Last event dispatch time is now the proper dispatch time rather than the time it was supposed to dispatch when the event actually gets dispatched. This desync may have occured if the bot reestablishes the API connection after the event was supposed to trigger, but still triggers.
 
 ### Optimised
-- All one time events and reminders for the next 24 are stored in memory, which should save on database queries.
+- All one time events and reminders for the next 24 hours are stored in memory, which should save on database queries.
 
 ## [0.5.0] - 18-12-2022
 ### Added

--- a/spacecat/modules/musicbox/musicbox.py
+++ b/spacecat/modules/musicbox/musicbox.py
@@ -597,6 +597,7 @@ class Musicbox(commands.Cog):
         return
 
     @app_commands.command()
+    @permissions.check()
     async def song(self: Self, interaction: discord.Interaction) -> None:
         """List information about the currently playing song."""
         music_player, _ = await self._find_music_player(interaction)

--- a/spacecat/spacecat.py
+++ b/spacecat/spacecat.py
@@ -14,6 +14,7 @@ import asyncio
 import contextlib
 import shutil
 import time
+import traceback
 from pathlib import Path
 from typing import TYPE_CHECKING, Self
 
@@ -73,6 +74,7 @@ class SpaceCat(commands.Bot):
                         f"Failed to load extension {module}\n"
                         f"{type(exception).__name__}: {exception}\n"
                     )
+                    traceback.print_exc()
 
     async def setup_server_data_tables(self: Self) -> None:
         """Sets up the server data table."""
@@ -208,6 +210,7 @@ class Core(commands.Cog):
                 "Command has errored. Contact the developers for help.", ephemeral=True
             )
             console.error(str(error))
+            traceback.format_exc()
 
     async def process_info(self: Self, channel: discord.abc.Messageable) -> None:
         """

--- a/spacecat/spacecat.py
+++ b/spacecat/spacecat.py
@@ -204,6 +204,9 @@ class Core(commands.Cog):
                 "You do not have permission to use this command.", ephemeral=True
             )
         else:
+            await interaction.response.send_message(
+                "Command has errored. Contact the developers for help.", ephemeral=True
+            )
             console.error(str(error))
 
     async def process_info(self: Self, channel: discord.abc.Messageable) -> None:

--- a/spacecat/spacecat.py
+++ b/spacecat/spacecat.py
@@ -191,7 +191,7 @@ class Core(commands.Cog):
                 return
 
     async def on_command_error(
-        self: Self, interaction: discord.Interaction, _: app_commands.AppCommandError
+        self: Self, interaction: discord.Interaction, error: app_commands.AppCommandError
     ) -> None:
         """
         Throws out users without permission to use the command.
@@ -199,9 +199,12 @@ class Core(commands.Cog):
         Args:
             interaction (discord.Interaction): The user interaction.
         """
-        await interaction.response.send_message(
-            "You do not have permission to use this command.", ephemeral=True
-        )
+        if isinstance(error, app_commands.CheckFailure):
+            await interaction.response.send_message(
+                "You do not have permission to use this command.", ephemeral=True
+            )
+        else:
+            console.error(str(error))
 
     async def process_info(self: Self, channel: discord.abc.Messageable) -> None:
         """

--- a/spacecat/spacecat.py
+++ b/spacecat/spacecat.py
@@ -196,10 +196,15 @@ class Core(commands.Cog):
         self: Self, interaction: discord.Interaction, error: app_commands.AppCommandError
     ) -> None:
         """
-        Throws out users without permission to use the command.
+        Handle errors when a command fails.
+
+        Permission errors are just alerted to the user, while all other
+        errors are also logged in the console.
 
         Args:
             interaction (discord.Interaction): The user interaction.
+            error (app_commands.AppCommandError): The error that was
+                raised.
         """
         if isinstance(error, app_commands.CheckFailure):
             await interaction.response.send_message(


### PR DESCRIPTION
Users are alerted of a permission error even if the error has nothing to do with lack of permissions. Error logs were also not shown in the console due to the override. This addresses the issue by checking to see if the permission is a check permission or not, and to handle it in the logs with its own warning if it isn't.